### PR TITLE
Add support for US Government clouds (GCC High / GCC / DoD)

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -874,7 +874,9 @@
       let cryptoKey = null;
       if (track.encryption) {
         reportProgress(`Fetching encryption key${label}...`);
-        const init = track.encryption.keyUri.includes('svc.ms') && videoSpopActoken
+        let keyIsCrossOrigin = true;
+        try { keyIsCrossOrigin = new URL(track.encryption.keyUri, window.location.href).host !== window.location.host; } catch (_) {}
+        const init = keyIsCrossOrigin && videoSpopActoken
           ? { signal, headers: { 'x-spopactoken': videoSpopActoken } }
           : { signal };
         const keyResp = await fetchWithRetry(track.encryption.keyUri, init, signal, noteThrottle);
@@ -1378,7 +1380,7 @@
     // path check above on that frame's location) or a Teams-internal player.
     // Treating the top frame as a video page surfaces the widget over the
     // Teams chrome where it'll never receive a manifest and stays "disabled".
-    if (/^teams\./.test(loc.hostname) && window !== window.top) return true;
+    if ((/^teams\./.test(loc.hostname) || /(^|\.)teams\.microsoft\.(com|us)$/.test(loc.hostname)) && window !== window.top) return true;
     return false;
   }
 

--- a/src/intercept.js
+++ b/src/intercept.js
@@ -42,7 +42,7 @@
     // "Anonymous or Email authenticated Guest User may not request tokens".
     if (url && typeof url === 'string' &&
         /\/_api\/v[0-9.]+\//.test(url) &&
-        url.includes('sharepoint.com')) {
+        /sharepoint(?:-mil)?\.(?:com|us)/.test(url)) {
       const auth = extractAuthorization(args);
       if (auth && /^Bearer\s+/i.test(auth)) {
         window.postMessage({ type: 'SP_API_BEARER', authorization: auth }, '*');

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -11,15 +11,21 @@
   ],
   "host_permissions": [
     "https://*.sharepoint.com/*",
+    "https://*.sharepoint.us/*",
+    "https://*.sharepoint-mil.us/*",
     "https://teams.microsoft.com/*",
-    "https://teams.cloud.microsoft/*"
+    "https://teams.cloud.microsoft/*",
+    "https://*.teams.microsoft.us/*"
   ],
   "content_scripts": [
     {
       "matches": [
         "https://*.sharepoint.com/*",
+        "https://*.sharepoint.us/*",
+        "https://*.sharepoint-mil.us/*",
         "https://teams.microsoft.com/*",
-        "https://teams.cloud.microsoft/*"
+        "https://teams.cloud.microsoft/*",
+        "https://*.teams.microsoft.us/*"
       ],
       "js": ["intercept.js"],
       "run_at": "document_start",
@@ -29,8 +35,11 @@
     {
       "matches": [
         "https://*.sharepoint.com/*",
+        "https://*.sharepoint.us/*",
+        "https://*.sharepoint-mil.us/*",
         "https://teams.microsoft.com/*",
-        "https://teams.cloud.microsoft/*"
+        "https://teams.cloud.microsoft/*",
+        "https://*.teams.microsoft.us/*"
       ],
       "js": ["content.js"],
       "css": ["modal.css"],
@@ -51,8 +60,11 @@
       "resources": ["intercept.js", "mux-worker.js"],
       "matches": [
         "https://*.sharepoint.com/*",
+        "https://*.sharepoint.us/*",
+        "https://*.sharepoint-mil.us/*",
         "https://teams.microsoft.com/*",
-        "https://teams.cloud.microsoft/*"
+        "https://teams.cloud.microsoft/*",
+        "https://*.teams.microsoft.us/*"
       ]
     }
   ]


### PR DESCRIPTION
The extension only matches `*.sharepoint.com` and the commercial Teams hosts, so it never loads on Microsoft 365 Government tenants. I hit this on a GCC High meeting recording opened from a `*.sharepoint.us` stream.aspx link: no widget, no console activity, because the content scripts aren't injected on that host in the first place.

Government tenants serve SharePoint and OneDrive from `*.sharepoint.us` (GCC / GCC High) and `*.sharepoint-mil.us` (DoD), and Teams from `gov.teams.microsoft.us` / `dod.teams.microsoft.us`. None of those match the current manifest patterns.

### Changes

**manifest.json** — adds `*.sharepoint.us`, `*.sharepoint-mil.us`, and `*.teams.microsoft.us` to `host_permissions`, both `content_scripts` match lists, and `web_accessible_resources`. This is what gets the scripts loading on gov hosts.

**intercept.js** — the Stream API bearer capture was gated on `url.includes('sharepoint.com')`, so the token was never grabbed on a `.us` host. Widened the check to the government hostnames.

**content.js**, two spots:

- The encryption-key fetch attached the `x-spopactoken` header only when the key URI contained `svc.ms`. I couldn't confirm which media CDN host a gov tenant issues the key from, so rather than hardcode a host it now attaches the token whenever the key URI is cross-origin to the page. That's the condition that the original `svc.ms` check was really standing in for, and it's a no-op for commercial since `svc.ms` is already cross-origin to `sharepoint.com`.
- The video-page heuristic only recognized hosts starting with `teams.`, which skips `gov.`/`dod.` Teams. Added those so the floating widget shows up there too.

The rest of the flow already keys off `window.location.origin` and path patterns (`/stream.aspx`, `/personal/`, `videomanifest`, `transcripts`), so it didn't need changes.

### Testing

I've confirmed the root cause and that the manifest change fixes injection: with the gov match patterns added, both scripts load on the `*.sharepoint.us` recording page and the manifest/bearer capture fires. I haven't run the full encrypted-video download end to end on a gov tenant yet, so a check on the video path from anyone with GCC High access would be welcome. The commercial path should be unaffected, since the host lists and the cross-origin key check are both supersets of the previous behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Extended support for additional SharePoint and Teams domains, including regional (.us) and cloud variants.
  * Updated domain detection logic for improved compatibility with Microsoft services across different environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/brendangooden/ms-teams-sharepoint-downloader/pull/14?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->